### PR TITLE
Adding java file extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,25 @@ target
 .DS_Store
 *.class
 *.jar
+
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*


### PR DESCRIPTION
In this PR added few additional java file extensions from https://github.com/github/gitignore/blob/main/Java.gitignore repository