### PR TITLE
Align Maven Java target with README

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<javaVersion>11</javaVersion>
+		<javaVersion>21</javaVersion>
 	</properties>
 	<modules>
 		<module>build-war</module>


### PR DESCRIPTION
## Summary
- update the root Maven javaVersion property from 11 to 21
- align Maven compiler source/target with the README Java 21 requirement

## Testing
- xmllint --noout pom.xml
- git diff --check
- not run: mvn test (mvn is not installed on this machine; current local JDK is 17)